### PR TITLE
Add DLC category

### DIFF
--- a/core/src/main/java/net/mabako/steamgifts/activities/Navbar.java
+++ b/core/src/main/java/net/mabako/steamgifts/activities/Navbar.java
@@ -268,7 +268,8 @@ public class Navbar {
             drawer.addItems(
                     new PrimaryDrawerItem().withName(R.string.navigation_giveaways_group).withIdentifier(R.string.navigation_giveaways_group).withIcon(FontAwesome.Icon.faw_users),
                     new PrimaryDrawerItem().withName(R.string.navigation_giveaways_wishlist).withIdentifier(R.string.navigation_giveaways_wishlist).withIcon(FontAwesome.Icon.faw_heart),
-                    new PrimaryDrawerItem().withName(R.string.navigation_giveaways_recommended).withIdentifier(R.string.navigation_giveaways_recommended).withIcon(FontAwesome.Icon.faw_thumbs_up));
+                    new PrimaryDrawerItem().withName(R.string.navigation_giveaways_recommended).withIdentifier(R.string.navigation_giveaways_recommended).withIcon(FontAwesome.Icon.faw_thumbs_up),
+                    new PrimaryDrawerItem().withName(R.string.navigation_giveaways_dlc).withIdentifier(R.string.navigation_giveaways_dlc).withIcon(FontAwesome.Icon.faw_download));
         }
         drawer.addItems(new PrimaryDrawerItem().withName(R.string.navigation_giveaways_new).withIdentifier(R.string.navigation_giveaways_new).withIcon(FontAwesome.Icon.faw_refresh));
     }

--- a/core/src/main/java/net/mabako/steamgifts/fragments/GiveawayListFragment.java
+++ b/core/src/main/java/net/mabako/steamgifts/fragments/GiveawayListFragment.java
@@ -344,6 +344,11 @@ public class GiveawayListFragment extends SearchableListFragment<GiveawayAdapter
         RECOMMENDED(R.string.navigation_giveaways_recommended, R.string.navigation_giveaways_recommended_title),
 
         /**
+         * DLC Giveaways.
+         */
+        DLC(R.string.navigation_giveaways_dlc, R.string.navigation_giveaways_dlc_title),
+
+        /**
          * New giveaways.
          */
         NEW(R.string.navigation_giveaways_new, R.string.navigation_giveaways_new_title);

--- a/core/src/main/java/net/mabako/steamgifts/tasks/LoadGiveawayListTask.java
+++ b/core/src/main/java/net/mabako/steamgifts/tasks/LoadGiveawayListTask.java
@@ -67,8 +67,11 @@ public class LoadGiveawayListTask extends AsyncTask<Void, Void, List<Giveaway>> 
             addFilterParameter(jsoup, "point_min", filterData.getMinPoints());
             addFilterParameter(jsoup, "point_max", filterData.getMaxPoints());
 
-            if (type != GiveawayListFragment.Type.ALL)
+            if (type == GiveawayListFragment.Type.DLC) {
+                jsoup.data("dlc", "true");
+            } else if (type != GiveawayListFragment.Type.ALL) {
                 jsoup.data("type", type.name().toLowerCase(Locale.ENGLISH));
+            }
 
             if (SteamGiftsUserData.getCurrent(fragment.getContext()).isLoggedIn())
                 jsoup.cookie("PHPSESSID", SteamGiftsUserData.getCurrent(fragment.getContext()).getSessionId());

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -9,11 +9,13 @@
     <string name="navigation_giveaways_group">Group</string>
     <string name="navigation_giveaways_wishlist">Wishlist</string>
     <string name="navigation_giveaways_recommended">Recommended</string>
+    <string name="navigation_giveaways_dlc">DLC</string>
     <string name="navigation_giveaways_new">New</string>
     <string name="navigation_giveaways_all_title">All Giveaways</string>
     <string name="navigation_giveaways_group_title">Group Giveaways</string>
     <string name="navigation_giveaways_wishlist_title">Wishlist Giveaways</string>
     <string name="navigation_giveaways_recommended_title">Recommended Giveaways</string>
+    <string name="navigation_giveaways_dlc_title">DLC Giveaways</string>
     <string name="navigation_giveaways_new_title">New Giveaways</string>
 
     <!-- Navigation for Discussions -->


### PR DESCRIPTION
The SteamGifts website has a way to show DLC giveaways. This PR adds that to the app.
<img width="107" alt="image" src="https://user-images.githubusercontent.com/5914284/161438315-4f938e70-3d9d-46a5-9650-daa2421700e7.png">
